### PR TITLE
FEAT: 드롭다운과 인스타/구글폼 이동

### DIFF
--- a/src/Home/Header.js
+++ b/src/Home/Header.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Styles from './Header.module.css';
 import { MdOutlineHistory } from 'react-icons/md';
+import { RiMenuLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 
 import { useRecoilState } from 'recoil';
@@ -36,6 +37,7 @@ const Header = ({ questionerStep, answererStep }) => {
     useRecoilState(OriginQuestionNum);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDropDownOpen, setIsDropDownOpen] = useState(false);
 
   const handleGoToMain = () => {
     if (
@@ -61,6 +63,18 @@ const Header = ({ questionerStep, answererStep }) => {
     setIsModalOpen(false);
   };
 
+  const handleDropdown = () => {
+    setIsDropDownOpen(!isDropDownOpen);
+  };
+
+  const handleGoToInsta = () => {
+    window.location.href = 'https://www.instagram.com/gom._.gom._.diary/';
+  };
+
+  const handleGoToForm = () => {
+    window.location.href = 'https://forms.gle/1TXShtN1kxS7zKqS6';
+  };
+
   return (
     <div className={Styles.Header}>
       <MdOutlineHistory
@@ -70,6 +84,13 @@ const Header = ({ questionerStep, answererStep }) => {
       <div className={Styles.title} onClick={handleGoToMain}>
         GomGom Diary 🐻💭
       </div>
+      <RiMenuLine className={Styles.menu} onClick={handleDropdown} />
+      {isDropDownOpen && (
+        <ul className={Styles.dropdown}>
+          <li onClick={handleGoToInsta}>공식 인스타그램</li>
+          <li onClick={handleGoToForm}>피드백</li>
+        </ul>
+      )}
       {isModalOpen && (
         <CustomModal
           message={'작성중에는 메인으로 갈 수 없어요.'}

--- a/src/Home/Header.module.css
+++ b/src/Home/Header.module.css
@@ -1,13 +1,13 @@
-@import '../App.css';
-
+/* Header.module.css */
 .Header {
   position: fixed;
   top: 0;
   left: 0;
+  box-sizing: border-box;
   width: 100%;
   display: flex;
   padding: 5px;
-  height: 25px;
+  height: 35px;
   background-color: var(--main-color);
   align-items: center;
   justify-content: center;
@@ -26,4 +26,36 @@
 
 .title {
   cursor: pointer;
+  position: relative;
+}
+
+.menu {
+  position: absolute;
+  font-size: 20px;
+  cursor: pointer;
+  right: 0;
+  margin-right: 10px;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 100%;
+  flex-direction: column;
+  background-color: white;
+  color: var(--point-color);
+  border: 1px solid rgb(230, 230, 230);
+  z-index: 1;
+  text-align: center;
+}
+
+.dropdown li {
+  list-style: none;
+  padding: 10px 0;
+  cursor: pointer;
+}
+
+.dropdown li:hover {
+  background-color: rgb(248, 248, 248);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 스타일 업데이트
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항

### 반영 브랜치

develop -> main

### 변경사항

- 헤더의 햄버거 메뉴 클릭 시 인스타그램, 구글 폼이 드롭다운으로 나옵니다.
- 해당하는 부분을 클릭하면 이동합니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
