### PR TITLE
FIX: 질문 수정 중 이전 버튼 활성화 버그 수정

### DIFF
--- a/src/Pages/Create/QuestionList.js
+++ b/src/Pages/Create/QuestionList.js
@@ -49,10 +49,12 @@ export const QuestionList = ({ onNextStep, onPreviousStep }) => {
   };
 
   const handlePrevious = () => {
-    if (currentQuestionIndex > 0) {
+    if (currentQuestionIndex > 0 && !isEdited) {
       setCurrentQuestionIndex(currentQuestionIndex - 1);
-    } else {
+    } else if (!isEdited) {
       onPreviousStep();
+    } else {
+      setIsCompleted(true);
     }
   };
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 스타일 업데이트
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항

### 반영 브랜치

develop -> main

### 변경사항

- 질문 수정 중 이전 버튼을 누르면 이전 단계로 넘어가는 버그를 수정했습니다.
- 따라서 질문 수정 중 이전, 다음, 메인으로 갈 수 없습니다. (히스토리는 가능 - 어처피 메인으로 라우팅됨)

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
