### PR TITLE
FIX: 카카오톡 공유하기 썸네일 안 나오는 버그 수정

### DIFF
--- a/src/Pages/Create/Finish.js
+++ b/src/Pages/Create/Finish.js
@@ -33,7 +33,7 @@ const Finish = ({ goToFirstStep }) => {
 
   const [isCopied, setIsCopied] = useState(false);
 
-  const handleShareLink = (link) => {
+  const handleShareLink = link => {
     // ?fbclid= 이후의 부분을 찾아 제거
     const indexOfFbclid = link.indexOf('?fbclid=');
     if (indexOfFbclid !== -1) {
@@ -51,7 +51,7 @@ const Finish = ({ goToFirstStep }) => {
           value: 1,
         });
       })
-      .catch((error) => {
+      .catch(error => {
         console.error('error', error);
       });
   };
@@ -69,7 +69,7 @@ const Finish = ({ goToFirstStep }) => {
       const kakaoAPI = process.env.REACT_APP_KAKAO_API;
 
       if (!Kakao.isInitialized()) {
-        await new Promise((resolve) => Kakao.init(kakaoAPI, resolve));
+        await new Promise(resolve => Kakao.init(kakaoAPI, resolve));
       }
 
       Kakao.Link.sendDefault({
@@ -77,7 +77,7 @@ const Finish = ({ goToFirstStep }) => {
         content: {
           title: '곰곰다이어리',
           description: '상대에 대해 곰곰이 생각하고 답해보세요!',
-          imageUrl: `${process.env.PUBLIC_URL}/image/OG_Thumb.png`,
+          imageUrl: 'https://gomgomdiary.site/image/OG_Thumb.png',
           link: {
             mobileWebUrl: `${location}diary/${userCookie}`,
             webUrl: `${location}diary/${userCookie}`,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 코드 스타일 업데이트
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항

### 반영 브랜치

feature/chat -> main

### 변경사항

카카오톡 공유하기 썸네일이 상대 경로로 작성되어 있어 노출되지 않아, 절대 경로로 수정했습니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
