### PR TITLE
feat: 히스토리에서 이전 다이어리 조회 갯수 제한을 풀었습니다.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,8 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: build using docker compose
-      - run: docker compose -p gomgom_front -f docker-compose.test.yml up —build —force-recreate —abort-on-container-exit
-
+        run: docker compose -p gomgom_front -f docker-compose.test.yml up —build —force-recreate —abort-on-container-exit
   push:
     if: github.event.repository.url != 'https://github.com/Yoowatney/GomGomFront' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     needs: build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: build using docker compose
-        run: docker-compose -p gomgom_front -f docker-compose.test.yml up --build --force-recreate --abort-on-container-exit
+      - run: docker compose -p gomgom_front -f docker-compose.test.yml up —build —force-recreate —abort-on-container-exit
+
   push:
     if: github.event.repository.url != 'https://github.com/Yoowatney/GomGomFront' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     needs: build
@@ -16,8 +17,8 @@ jobs:
     container: pandoc/latex
     steps:
       - uses: actions/checkout@v4
-      - name : Create directory
-        run : sh ./build.sh || ls -al
+      - name: Create directory
+        run: sh ./build.sh || ls -al
           echo ${{ github.event.repository.name }}
       - name: Pushes to another repository
         id: push_directory
@@ -26,7 +27,7 @@ jobs:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
           source-directory: .
-          destination-github-username: "Yoowatney"
-          destination-repository-name: "GomGomFront"
+          destination-github-username: 'Yoowatney'
+          destination-repository-name: 'GomGomFront'
           commit-message: ${{ github.event.commits[0].message }}
           target-branch: main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: build using docker compose
-        run: docker compose -p gomgom_front -f docker-compose.test.yml up —build —force-recreate —abort-on-container-exit
+        run: docker compose -p gomgom_front -f docker-compose.test.yml up --build --force-recreate --abort-on-container-exit
   push:
     if: github.event.repository.url != 'https://github.com/Yoowatney/GomGomFront' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
     needs: build

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,6 @@
-version: "3"
-
 services:
   web:
-    build: 
+    build:
       context: .
       dockerfile: ./Dockerfile
     command: npm run build

--- a/src/Pages/History/History.js
+++ b/src/Pages/History/History.js
@@ -120,7 +120,9 @@ const History = () => {
       }
     }
 
-    const { data: getId } = await axiosInstance.get(`history/${userId}`);
+    const { data: getId } = await axiosInstance.get(
+      `history/${userId}?take=5&start=5`
+    );
 
     const historyItemId = getId._id;
     navigate(`/history/${historyItemId}`);

--- a/src/Pages/History/HistoryItem.module.css
+++ b/src/Pages/History/HistoryItem.module.css
@@ -91,3 +91,23 @@
   color: var(--point-color);
   text-align: right;
 }
+
+.pageBtns button {
+  border: none;
+  background-color: var(--main-color);
+  border-radius: 100%;
+  width: 20px;
+  height: 20px;
+  color: white;
+  font-size: 16px;
+  cursor: pointer;
+  margin: 3px;
+}
+
+.pageBtns .currentPage {
+  background-color: var(--point-color);
+}
+
+.pageBtns .isEndBtn {
+  background-color: lightgray;
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 스타일 업데이트
- [x] 빌드 관련 변경사항
- [ ] CI 관련 변경사항

### 반영 브랜치

feature/chat -> main

### 변경사항

- as is
  - 히스토리에서 이전 다이어리 조회 시 한 다이어리 당 가장 오래된 답변 5개만 조회 가능
 
- to be
  - 갯수 제한 없이 누적된 답장 개수만큼 조회 가능
 
- docker
  - 이유를 알 수 없으나 version 코드 삭제, docker-compose -> docker componse로 수정해 빌드 에러 수정 ([참고](https://github.com/orgs/community/discussions/116610))

### 테스트 결과


https://github.com/user-attachments/assets/89c3b59b-a328-4e12-8487-136cd185ca27

