### PR TITLE
fix: 히스토리 수정사항에 맞춰 모달 메세지 수정

### DIFF
--- a/src/Pages/Create/DisplayAnswerList.js
+++ b/src/Pages/Create/DisplayAnswerList.js
@@ -477,7 +477,7 @@ const DisplayAnswerList = ({ goToFirstStep }) => {
       {wantNewDiary && (
         <ConfirmModal
           message={`새로 만들면 이전 다이어리는 저장됩니다.
-            저장된 다이어리는 최근 답장 5개만 볼 수 있어요.`}
+            (왼쪽 시계를 클릭하면 이전 다이어리를 볼 수 있어요!)`}
           updateModal={handleModalClose}
           goToFirstStep={goToFirstStep}
         />

--- a/src/components/CustomModal.module.css
+++ b/src/components/CustomModal.module.css
@@ -3,8 +3,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100px;
-  width: 290px;
+  height: 120px;
+  width: 315px;
   top: 15%;
   left: 50%;
   transform: translateX(-50%);
@@ -74,8 +74,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 300px;
   height: 350px;
-  width: 290px;
   top: 15%;
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 스타일 업데이트
- [ ] 빌드 관련 변경사항
- [ ] CI 관련 변경사항

### 반영 브랜치

feature/chat -> main

### 변경사항

히스토리 변경 사항을 반영하여 새로 다이어리 만들 때 안내 메세지를 수정했습니다.

- as is
<img width="377" alt="image" src="https://github.com/user-attachments/assets/889696bd-ed3c-4fe9-b43d-bdf0b64567a8">


- to be
<img width="373" alt="image" src="https://github.com/user-attachments/assets/c6777045-54ce-4f2e-a1da-eb7a66eb3f52">


### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
